### PR TITLE
Redirect to existing portfolio website on page load

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,20 +1,30 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
-    <title>Hi, I'm Moses</title>
+    <title>Hi, I'm Moses (deprecated)</title>
     <link rel="stylesheet" href="reset.css" />
     <link rel="stylesheet" href="index.css" />
   </head>
   <body>
-    <style src="index.css"></style>
-    <h1>This site is a work in progress...</h1>
-    <h2>
-      Visit
-      <a href="https://mosessupposes.github.io/portfolio-website/">this link</a>
-      to view my portfolio.
-    </h2>
+    <header>
+      <h1>Moses</h1>
+      </nav>
+    <main>
+      <h1>This site has been deprecated.</h1>
+      <h2>
+        Visit
+        <a href="https://mosessupposes.github.io/portfolio-website/"
+          >this link</a
+        >
+        to view my portfolio.
+      </h2>
+    </main>
+    <script src="utils.js"></script>
+    <script src="index.js">
+    </script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,17 +1,20 @@
 <!DOCTYPE html>
 <html lang="en">
-	<head>
-		<meta charset="UTF-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<meta http-equiv="X-UA-Compatible" content="ie=edge" />
-		<title>Hi, I'm Moses</title>
-	</head>
-	<body>
-		<h1>This site is a work-in-progress...</h1>
-		<h2>
-			Visit
-			<a href="https://mosessupposes.github.io/portfolio-website/">this link</a>
-			to view my portfolio.
-		</h2>
-	</body>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Hi, I'm Moses</title>
+    <link rel="stylesheet" href="reset.css" />
+    <link rel="stylesheet" href="index.css" />
+  </head>
+  <body>
+    <style src="index.css"></style>
+    <h1>This site is a work in progress...</h1>
+    <h2>
+      Visit
+      <a href="https://mosessupposes.github.io/portfolio-website/">this link</a>
+      to view my portfolio.
+    </h2>
+  </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -1,0 +1,7 @@
+const portfolioWebsiteUrl =
+  "https://mosessupposes.github.io/portfolio-website/";
+
+window.addEventListener("load", () => {
+  const redirectToPortfolioWebsite = redirectTo(portfolioWebsiteUrl);
+  redirectToPortfolioWebsite();
+});

--- a/reset.css
+++ b/reset.css
@@ -1,0 +1,68 @@
+/* CSS Reset */
+
+/* Box sizing rules */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+/* Remove default margin */
+body,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+ol,
+ul {
+  margin: 0;
+}
+
+/* Remove default padding */
+body,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+ol,
+ul {
+  padding: 0;
+}
+
+/* Remove list styles (bullet points) */
+ol,
+ul {
+  list-style: none;
+}
+
+/* Remove default hyperlink styles */
+a {
+  text-decoration: none;
+  color: inherit;
+}
+
+/* Reset form elements */
+button,
+input,
+optgroup,
+select,
+textarea {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-size: 100%;
+  font-family: inherit;
+  vertical-align: baseline;
+}
+
+/* Make images responsive */
+img {
+  max-width: 100%;
+  height: auto;
+}

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,5 @@
+function redirectTo(url) {
+  return function () {
+    window.location.href = "https://mosessupposes.github.io/portfolio-website/";
+  };
+}


### PR DESCRIPTION
This change deprecates the existing html document at the `/` route and  redirects the viewer to `mosessupposes.github.io/portfolio-website` upon page load.