### PR TITLE
remove-deprecation notice from title

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
-    <title>Hi, I'm Moses (deprecated)</title>
+    <title>Hi, I'm Moses</title>
     <link rel="stylesheet" href="reset.css" />
     <link rel="stylesheet" href="index.css" />
   </head>


### PR DESCRIPTION
Removed `deprecated` from the document title of the `/` route, this way links to the portfolio website look legit.